### PR TITLE
3 - Create a CLI flag for package.json filepath or branch suffix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,5 @@ jobs:
         with:
           cache: "npm"
       - run: npm ci
+      - run: npm run lint
       - run: npm run test

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ npx npm-gitver
 
 This will execute the package directly from the command line, creating or updating the version based on Git tags.
 
+### Specifying a Custom `package.json` File Path
+
+If your `package.json` file is located in a custom directory, you can use the `--file` or `-f` flag to specify its path:
+
+```bash
+npx npm-gitver --file ./path/to/package.json
+```
+
+or
+
+```bash
+npx npm-gitver -f ./path/to/package.json
+```
+
+This will use the specified `package.json` file to determine the base version and update it accordingly.
+
 ## Linting
 
 Follow best practices for linting your code. Refer to the ESLint documentation for setup and configuration:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ npx npm-gitver -f ./path/to/package.json
 
 This will use the specified `package.json` file to determine the base version and update it accordingly.
 
+### Including the Git Branch in the Version
+
+You can use the `--branch` flag to include the current Git branch name in the generated version. This is useful for identifying builds from different branches.
+
+```bash
+npx npm-gitver --branch
+```
+
+or
+
+```bash
+npx npm-gitver -b
+```
+
+When using this flag, the generated version will include the branch name as a prefix to the Git SHA, formatted as `<branch>.<sha>`. For example, if the branch is `feature/new-feature` and the Git SHA is `abc123`, the version will look like:
+
+```
+1.0.0-feature-new-feature.abc123
+```
+
+Note: Slashes (`/`) in branch names will be replaced with dashes (`-`), and any unsafe characters will be removed.
+
 ## Linting
 
 Follow best practices for linting your code. Refer to the ESLint documentation for setup and configuration:

--- a/bin/npm-gitver.js
+++ b/bin/npm-gitver.js
@@ -6,13 +6,17 @@ const { generateGitVersion } = require('../index');
 const args = process.argv.slice(2);
 
 let filePath = './package.json'; // default file path to package.json
+let includeBranch = false;        // whether to include branch name
 
 for (let i = 0; i < args.length; i++) {
     if (args[i] === '--file' || args[i] === '-f') {
         filePath = args[i + 1];
         i++;
     }
+    if (args[i] === '--branch' || args[i] === '-b') {
+        includeBranch = true;
+    }
 }
 
-const version = generateGitVersion(filePath);
+const version = generateGitVersion(filePath, { includeBranch });
 console.log(version);

--- a/bin/npm-gitver.js
+++ b/bin/npm-gitver.js
@@ -2,5 +2,17 @@
 
 const { generateGitVersion } = require('../index');
 
+// argument parser
+const args = process.argv.slice(2);
+
+let filePath = './package.json'; // default file path to package.json
+
+for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--file' || args[i] === '-f') {
+        filePath = args[i + 1];
+        i++;
+    }
+}
+
 const version = generateGitVersion();
 console.log(version);

--- a/bin/npm-gitver.js
+++ b/bin/npm-gitver.js
@@ -14,5 +14,5 @@ for (let i = 0; i < args.length; i++) {
     }
 }
 
-const version = generateGitVersion();
+const version = generateGitVersion(filePath);
 console.log(version);

--- a/index.js
+++ b/index.js
@@ -15,17 +15,32 @@ function readPackageJson(filePath = './package.json') {
     return JSON.parse(raw);
 }
 
-function generateGitVersion(filePath) {
+function generateGitVersion(filePath, options = {}) {
     const sha = getShortGitSHA();
     const pkg = readPackageJson(filePath);
 
     if (!pkg.version) {
         throw new Error('The "version" key is missing in package.json.');
     }
+
     const baseVersion = pkg.version.split('-')[0]; // remove any pre-release suffix
-    const newVersion = `${baseVersion}-${sha}`;
+
+    let suffix = sha;
+
+    if (options.includeBranch) {
+        const branch = getGitBranch()
+            .replace(/\//g, '-')   // replace slashes in branch name for safety
+            .replace(/[^\w\-]/g, ''); // remove any unsafe characters
+        suffix = `${branch}.${sha}`;
+    }
+
+    const newVersion = `${baseVersion}-${suffix}`;
 
     return newVersion;
+}
+
+function getGitBranch() {
+    return childProcess.execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ function getShortGitSHA() {
     return childProcess.execSync('git rev-parse --short HEAD').toString().trim();
 }
 
-function readPackageJson() {
-    const pkgPath = path.resolve(process.cwd(), 'package.json');
+function readPackageJson(filePath = './package.json') {
+    const pkgPath = path.resolve(process.cwd(), filePath);
     if (!fs.existsSync(pkgPath)) {
         throw new Error('package.json not found in the current working directory.');
     }
@@ -15,9 +15,9 @@ function readPackageJson() {
     return JSON.parse(raw);
 }
 
-function generateGitVersion() {
+function generateGitVersion(filePath) {
     const sha = getShortGitSHA();
-    const pkg = readPackageJson();
+    const pkg = readPackageJson(filePath);
 
     if (!pkg.version) {
         throw new Error('The "version" key is missing in package.json.');

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function generateGitVersion(filePath, options = {}) {
     if (options.includeBranch) {
         const branch = getGitBranch()
             .replace(/\//g, '-')   // replace slashes in branch name for safety
+            // eslint-disable-next-line no-useless-escape
             .replace(/[^\w\-]/g, ''); // remove any unsafe characters
         suffix = `${branch}.${sha}`;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-gitver",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "npm gitver is a simple command line tool that allows you to easily manage your git versioning.",
   "bin": {
     "npm-gitver": "./bin/npm-gitver.js"

--- a/test/branch.test.js
+++ b/test/branch.test.js
@@ -1,0 +1,37 @@
+const { writeFileSync, unlinkSync } = require('fs');
+const childProcess = require('child_process');
+const { generateGitVersion } = require('../index');
+const { test } = require('node:test');
+const assert = require('assert');
+const sinon = require('sinon');
+
+const TEMP_PACKAGE_PATH = './test/temp-package.json';
+
+test('generateGitVersion correctly appends branch name and Git SHA to package version with --branch flag', async () => {
+    // Arrange
+    const fakePackage = {
+        name: "fake-package",
+        version: "2.5.7"
+    };
+    writeFileSync(TEMP_PACKAGE_PATH, JSON.stringify(fakePackage, null, 2));
+
+    // Mock Git commands
+    const shortSHA = 'abc123';
+    const branchName = 'feature/test-branch';
+    const execSyncStub = sinon.stub(childProcess, 'execSync');
+    execSyncStub.withArgs('git rev-parse --short HEAD').returns(shortSHA);
+    execSyncStub.withArgs('git rev-parse --abbrev-ref HEAD').returns(branchName);
+
+    // Act
+    const result = generateGitVersion(TEMP_PACKAGE_PATH, { includeBranch: true });
+
+    // Assert
+    const expected = `2.5.7-feature-test-branch.${shortSHA}`;
+    assert.strictEqual(result, expected);
+
+    // Cleanup
+    unlinkSync(TEMP_PACKAGE_PATH);
+
+    // Restore stubs
+    execSyncStub.restore();
+});

--- a/test/filePath.test.js
+++ b/test/filePath.test.js
@@ -1,0 +1,29 @@
+const { writeFileSync, unlinkSync } = require('fs');
+const childProcess = require('child_process');
+const { generateGitVersion } = require('../index');
+const { test } = require('node:test');
+const assert = require('assert');
+
+const TEMP_PACKAGE_PATH = './test/temp-package.json';
+
+test('generateGitVersion correctly appends Git SHA to package version', async (t) => {
+    // Arrange
+    const fakePackage = {
+        name: "fake-package",
+        version: "2.5.7"
+    };
+    writeFileSync(TEMP_PACKAGE_PATH, JSON.stringify(fakePackage, null, 2));
+
+    // Get current short Git SHA
+    const shortSHA = childProcess.execSync('git rev-parse --short HEAD').toString().trim();
+
+    // Act
+    const result = generateGitVersion(TEMP_PACKAGE_PATH);
+
+    // Assert
+    const expected = `2.5.7-${shortSHA}`;
+    assert.strictEqual(result, expected);
+
+    // Cleanup
+    unlinkSync(TEMP_PACKAGE_PATH);
+});

--- a/test/filePath.test.js
+++ b/test/filePath.test.js
@@ -4,9 +4,9 @@ const { generateGitVersion } = require('../index');
 const { test } = require('node:test');
 const assert = require('assert');
 
-const TEMP_PACKAGE_PATH = './test/temp-package.json';
+const TEMP_PACKAGE_PATH = './test/package.json';
 
-test('generateGitVersion correctly appends Git SHA to package version', async (t) => {
+test('generateGitVersion correctly appends Git SHA to package version', async () => {
     // Arrange
     const fakePackage = {
         name: "fake-package",

--- a/test/generateGitVersion.test.js
+++ b/test/generateGitVersion.test.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const { test } = require('node:test');
 const sinon = require('sinon');
 
-test('should generate a version with Git SHA when package.json is valid', (t) => {
+test('should generate a version with Git SHA when package.json is valid', () => {
     // Mock dependencies
     const execSyncStub = sinon.stub(childProcess, 'execSync').returns('abc123');
     const existsSyncStub = sinon.stub(fs, 'existsSync').returns(true);
@@ -25,7 +25,7 @@ test('should generate a version with Git SHA when package.json is valid', (t) =>
     }
 });
 
-test('should throw an error if package.json is missing', (t) => {
+test('should throw an error if package.json is missing', () => {
     // Mock dependencies
     const existsSyncStub = sinon.stub(fs, 'existsSync').returns(false);
 
@@ -40,7 +40,7 @@ test('should throw an error if package.json is missing', (t) => {
     }
 });
 
-test('should throw an error if version key is missing in package.json', (t) => {
+test('should throw an error if version key is missing in package.json', () => {
     // Mock dependencies
     const existsSyncStub = sinon.stub(fs, 'existsSync').returns(true);
     const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns(JSON.stringify({}));
@@ -57,7 +57,7 @@ test('should throw an error if version key is missing in package.json', (t) => {
     }
 });
 
-test('should throw an error if Git SHA cannot be retrieved', (t) => {
+test('should throw an error if Git SHA cannot be retrieved', () => {
     // Mock dependencies
     const existsSyncStub = sinon.stub(fs, 'existsSync').returns(true);
     const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns(JSON.stringify({ version: '1.0.0' }));


### PR DESCRIPTION
# Pull Request

The user can use `--file` or `-f` to specify the file path to the package.json.

They can also use `--branch` or `-b` to add the branch suffix to the version.

## Testing Instructions (or AC)

- [ ] All tests should pass
- [ ] You should be able to use CLI flags `--file` and `--branch` 
